### PR TITLE
Properly hide the toolbar along with the menu bar in fullscreen mode

### DIFF
--- a/VirtualApple/WindowController.swift
+++ b/VirtualApple/WindowController.swift
@@ -38,6 +38,10 @@ class WindowController: NSWindowController, NSWindowDelegate {
 
 		runSetupWorkflow()
 	}
+	
+	func window(_ window: NSWindow, willUseFullScreenPresentationOptions proposedOptions: NSApplication.PresentationOptions) -> NSApplication.PresentationOptions {
+		return [proposedOptions, .autoHideToolbar]
+	}
 
 	func windowWillClose(_ notification: Notification) {
 		retainedSelf = nil


### PR DESCRIPTION
HiDPI (Retina) display modes were completely broken due to the display width and height erroneously being multiplied by the configured display scaling value (@​2x in this case).

Also, a slightly incorrect base PPI value of `100` was being used, and has been corrected to `144`. (※ This technically has no noticeable effect to the end-user unlike the display mode issue above, as macOS will happily scale to @​2x even at the previous PPI value of `200`. That being said, `288` (as a multiple of `72`) is technically the "proper" PPI value to use here for macOS guests.)

With the previous behaviour, specifying a display mode of 3456×2160@2x would actually result in a 6912×4320@2x display mode being passed to the guest OS, instead of the correct value of 3456×2160@2x.

This PR fixes both issues by leaving the width and height values of the configured display mode as-is, resulting in the "Retina" configuration option only simply changing the PPI presented to the guest OS (calculated by multiplying the base PPI value by the configured scaling value, which is always 2).

It also fixes a rather annoying UI issue where the toolbar was not being hidden in fullscreen mode.

---

(※ I am aware that UTM largely supercedes VirtualApple nowadays in terms of overall UX and features, but it unfortunately still doesn't support the necessary private API calls for entering paired 1TR that VirtualApple does (on macOS 12 hosts, anyway), and it also lacks pretty much all of the other private API features VirtualApple has access to.

For that reason, I've been using [a script I wrote](https://gist.github.com/akemin-dayo/8337d8274deddfefae5d1543420ca0b1.git) to create a VirtualApple VM instance with a hardlinked `disk.img`/`aux.img` and a `metadata.json` using values from UTM's `config.plist` for whenever I need to enter paired 1TR.)